### PR TITLE
Add excerpt support

### DIFF
--- a/android/src/main/java/org/dwbn/plugins/playlist/data/AudioTrack.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/data/AudioTrack.kt
@@ -32,6 +32,12 @@ class AudioTrack (private val config: JSONObject) : PlaylistItem {
             info.put("artist", artist)
             info.put("album", album)
             info.put("title", title)
+            if (startTime > 0) {
+                info.put("startTime", startTime)
+            }
+            if (endTime != null) {
+                info.put("endTime", endTime)
+            }
         } catch (e: JSONException) {
             // I can think of no reason this would ever fail
         }
@@ -90,5 +96,22 @@ class AudioTrack (private val config: JSONObject) : PlaylistItem {
 
     override val artist: String
         get() = config.optString("artist")
+
+    /**
+     * Start time in seconds for audio excerpt playback. If not provided, playback starts from the beginning.
+     * This allows playing only a portion of a longer audio file.
+     */
+    val startTime: Double
+        get() = config.optDouble("startTime", 0.0)
+
+    /**
+     * End time in seconds for audio excerpt playback. If not provided, playback continues to the end of the file.
+     * This allows playing only a portion of a longer audio file.
+     */
+    val endTime: Double?
+        get() {
+            val endTime = config.optDouble("endTime", -1.0)
+            return if (endTime < 0) null else endTime
+        }
 
 }

--- a/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
+++ b/android/src/main/java/org/dwbn/plugins/playlist/manager/PlaylistManager.kt
@@ -298,6 +298,7 @@ class PlaylistManager(application: Application) :
 
     fun beginPlayback(@IntRange(from = 0) seekPosition: Long, startPaused: Boolean) {
         currentItem ?: return
+        Log.w(TAG, "beginPlayback: seekPosition = $seekPosition, startPaused = $startPaused")
         super.play(seekPosition, startPaused)
         try {
             setVolume(volumeLeft, volumeRight)

--- a/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
+++ b/android/src/main/java/org/dwbn/plugins/playlist/playlist/AudioPlaylistHandler.java
@@ -54,7 +54,7 @@ public class AudioPlaylistHandler<I extends PlaylistItem, M extends BasePlaylist
             return;
         }
         getPlaylistManager().next();
-        startItemPlayback(0, !this.isPlaying());
+        ((PlaylistManager) getPlaylistManager()).beginPlayback(1, !this.isPlaying());
     }
 
     public void previous() {
@@ -62,7 +62,7 @@ public class AudioPlaylistHandler<I extends PlaylistItem, M extends BasePlaylist
             return;
         }
         getPlaylistManager().previous();
-        startItemPlayback(0, !this.isPlaying());
+        ((PlaylistManager) getPlaylistManager()).beginPlayback(1, !this.isPlaying());
     }
 
     @Override

--- a/ios/Plugin/AudioTrack.swift
+++ b/ios/Plugin/AudioTrack.swift
@@ -14,6 +14,8 @@ final class AudioTrack: AVPlayerItem {
     var artist: String?
     var album: String?
     var title: String?
+    var startTime: Double = 0.0
+    var endTime: Double?
 
     class func initWithDictionary(_ trackInfo: [String : Any]?) -> AudioTrack? {
         guard
@@ -41,11 +43,19 @@ final class AudioTrack: AVPlayerItem {
         track.album = trackInfo["album"] as? String
         track.title = trackInfo["title"] as? String
         
+        // Handle excerpt timing
+        if let startTime = trackInfo["startTime"] as? NSNumber {
+            track.startTime = startTime.doubleValue
+        }
+        if let endTime = trackInfo["endTime"] as? NSNumber {
+            track.endTime = endTime.doubleValue
+        }
+        
         return track
     }
 
     func toDict() -> [String : Any]? {
-        [
+        var dict: [String : Any] = [
             "isStream": NSNumber(value: isStream),
             "trackId": trackId ?? "",
             "assetUrl": assetUrl?.absoluteString ?? "",
@@ -54,5 +64,14 @@ final class AudioTrack: AVPlayerItem {
             "album": album ?? "",
             "title": title ?? ""
         ]
+        
+        if startTime > 0 {
+            dict["startTime"] = NSNumber(value: startTime)
+        }
+        if let endTime = endTime {
+            dict["endTime"] = NSNumber(value: endTime)
+        }
+        
+        return dict
     }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -121,6 +121,16 @@ export interface AudioTrack {
      * Title of the track
      */
     title: string;
+    /**
+     * Start time in seconds for audio excerpt playback. If not provided, playback starts from the beginning.
+     * This allows playing only a portion of a longer audio file.
+     */
+    startTime?: number;
+    /**
+     * End time in seconds for audio excerpt playback. If not provided, playback continues to the end of the file.
+     * This allows playing only a portion of a longer audio file.
+     */
+    endTime?: number;
 }
 
 /**
@@ -216,11 +226,16 @@ export interface OnStatusCallbackUpdateData {
      */
     status: 'unknown' | 'ready' | 'error' | 'playing' | 'loading' | 'paused';
     /**
-     * Current playback position of the reported track.
+     * Current playback position of the reported track, relative to the excerpt start time.
+     * For tracks with startTime/endTime, this represents the position within the excerpt (0 to excerpt duration).
+     * For full tracks, this represents the position from the beginning of the file.
      */
     currentPosition: number;
     /**
-     * The known duration of the reported track. For streams or malformed MP3's, this value will be 0.
+     * The known duration of the reported track, relative to the excerpt.
+     * For tracks with startTime/endTime, this represents the excerpt duration (endTime - startTime).
+     * For full tracks, this represents the full file duration.
+     * For streams or malformed MP3's, this value will be 0.
      */
     duration: number;
     /**


### PR DESCRIPTION
This enables the user to provide a start/end time and only plays that section of the file. It makes both the system player and the client app think that the excerpt is the full file by translating the timestamps/duration on all calls.