### PR TITLE
fix(ios): use playback audio session for CarPlay testing

### DIFF
--- a/ios/Plugin/RmxAudioPlayer.swift
+++ b/ios/Plugin/RmxAudioPlayer.swift
@@ -1207,16 +1207,10 @@ final class RmxAudioPlayer: NSObject {
     func activateAudioSession() {
         let avSession = AVAudioSession.sharedInstance()
 
-        // If no devices are connected, play audio through the default speaker (rather than the earpiece).
-        var options: AVAudioSession.CategoryOptions = .defaultToSpeaker
-
-        // If both Bluetooth streaming options are enabled, the low quality stream is preferred; enable A2DP only.
-        options.insert(.allowBluetoothA2DP)
-
         do {
-            // Always set category first, even if session is already active
-            // This ensures we have the correct category after video player exits
-            try avSession.setCategory(.playAndRecord, options: options)
+            // This plugin is playback-only; recording categories can change routing
+            // and processing on external outputs like CarPlay.
+            try avSession.setCategory(.playback, options: [])
         } catch {
             print("Error setting category! \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Summary
- switch the iOS audio session from `.playAndRecord` to plain `.playback`
- remove speaker and Bluetooth routing options so this CarPlay test isolates category-driven routing or processing changes
- keep the existing session activation flow unchanged

## Testing
- npm run verify:ios